### PR TITLE
:+1: add: SSR Authorizer

### DIFF
--- a/cdk/lib/aws-cognito-auth-trial-app-stack.ts
+++ b/cdk/lib/aws-cognito-auth-trial-app-stack.ts
@@ -111,7 +111,7 @@ export class AwsCognitoAuthTrialAppStack extends Stack {
       taskDefinition,
       securityGroups: [ecsSecurityGroup],
       publicLoadBalancer: true,
-      //redirectHTTP: true,
+      redirectHTTP: true,
       sslPolicy: SslPolicy.RECOMMENDED,
       certificate: Certificate.fromCertificateArn(this, 'Cert', certificateArn),
     });

--- a/cdk/lib/aws-cognito-auth-trial-app-stack.ts
+++ b/cdk/lib/aws-cognito-auth-trial-app-stack.ts
@@ -111,7 +111,7 @@ export class AwsCognitoAuthTrialAppStack extends Stack {
       taskDefinition,
       securityGroups: [ecsSecurityGroup],
       publicLoadBalancer: true,
-      redirectHTTP: true,
+      //redirectHTTP: true,
       sslPolicy: SslPolicy.RECOMMENDED,
       certificate: Certificate.fromCertificateArn(this, 'Cert', certificateArn),
     });

--- a/src/hooks/use-greeting-message.tsx
+++ b/src/hooks/use-greeting-message.tsx
@@ -1,7 +1,7 @@
 import axios from "axios";
 import {useEffect, useState} from "react";
 
-export const useGreetingMessage = (username: string) => {
+export const useGreetingMessage = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
@@ -13,7 +13,7 @@ export const useGreetingMessage = (username: string) => {
     setErrorMessage('');
 
     const f = async () => {
-      return await getGreetingMessage(username);
+      return await getGreetingMessage();
     }
 
     f().then(r => {
@@ -36,8 +36,8 @@ export const useGreetingMessage = (username: string) => {
   };
 };
 
-const getGreetingMessage: (username: string) => Promise<GreetingMessage> = async (username) => {
-  const message = 'Welcome! ' + username;
+const getGreetingMessage: () => Promise<GreetingMessage> = async () => {
+  const message = 'Welcome!';
   return await axios
     .get('/api/greeting/' + message, {
       headers: {

--- a/src/lib/ssr-authorizer.tsx
+++ b/src/lib/ssr-authorizer.tsx
@@ -1,0 +1,19 @@
+import {NextApiRequest, NextApiResponse} from 'next';
+import {withSSRContext} from 'aws-amplify';
+
+export const SsrAuthorizer = async (req: NextApiRequest, res: NextApiResponse) => {
+  const {Auth} = withSSRContext({req: req});
+
+  return await Auth.currentAuthenticatedUser({bypassCache: false})
+    .then((result: any) => result)
+    .catch((e: any) => {
+      console.error('401 - Unauthorized');
+      console.warn(e);
+      res.status(401)
+        .json({
+          status: 401,
+          message: 'Unauthorized',
+        });
+      throw new Error('401 - Unauthorized');
+    });
+};

--- a/src/pages/api/greeting/[message].tsx
+++ b/src/pages/api/greeting/[message].tsx
@@ -5,20 +5,6 @@ import {SsrAuthorizer} from "../../../lib/ssr-authorizer";
 const GreetingMessageHandler: NextApiHandler = async (req, res) => {
   const auth: any = await SsrAuthorizer(req, res);
 
-  // const {Auth} = withSSRContext({req: req});
-  // const auth = await Auth.currentAuthenticatedUser({bypassCache: false})
-  //   .then((result: any) => result)
-  //   .catch((e: any) => {
-  //     console.error('401 - Unauthorized');
-  //     console.warn(e);
-  //     res.status(401)
-  //       .json({
-  //         status: 401,
-  //         message: 'Unauthorized',
-  //       });
-  //     throw new Error('401 - Unauthorized');
-  //   });
-
   const session = auth.signInUserSession;
   const {payload} = session.getIdToken();
   const cognitoGroupNames = payload['cognito:groups'];

--- a/src/pages/api/greeting/[message].tsx
+++ b/src/pages/api/greeting/[message].tsx
@@ -1,10 +1,38 @@
 import {NextApiHandler} from "next";
+import {withSSRContext} from "aws-amplify";
+import {SsrAuthorizer} from "../../../lib/ssr-authorizer";
 
 const GreetingMessageHandler: NextApiHandler = async (req, res) => {
+  const auth: any = await SsrAuthorizer(req, res);
+
+  // const {Auth} = withSSRContext({req: req});
+  // const auth = await Auth.currentAuthenticatedUser({bypassCache: false})
+  //   .then((result: any) => result)
+  //   .catch((e: any) => {
+  //     console.error('401 - Unauthorized');
+  //     console.warn(e);
+  //     res.status(401)
+  //       .json({
+  //         status: 401,
+  //         message: 'Unauthorized',
+  //       });
+  //     throw new Error('401 - Unauthorized');
+  //   });
+
+  const session = auth.signInUserSession;
+  const {payload} = session.getIdToken();
+  const cognitoGroupNames = payload['cognito:groups'];
+
+  console.log('========== Auth ==========');
+  console.log(auth);
+  console.log(cognitoGroupNames);
+  console.log('username: ' + auth.username);
+  console.log('==========================');
+
   const {message} = req.query;
 
   const responseBody = {
-    'message': message,
+    'message': message + ' ' + auth.username,
   }
 
   res.status(200).json(responseBody)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,7 +12,7 @@ const Welcome: NextPage = (props: PropsWithChildren<Props>) => {
   const auth = useAuth();
   const [isAuthFailed, setAuthFailed] = useState(false);
 
-  const {isLoading, isError, errorMessage, greetingMessage} = useGreetingMessage(auth.username);
+  const {isLoading, isError, errorMessage, greetingMessage} = useGreetingMessage();
 
   const signOut = async (e: any) => {
     e.preventDefault();
@@ -36,7 +36,7 @@ const Welcome: NextPage = (props: PropsWithChildren<Props>) => {
     <div className={'flex m-4'}>
       <Box>
         <div className={'mb-4'}><h1>{greetingMessage?.message}</h1></div>
-        <div className={'mb-4'}><h3>Login: {auth.isAuthenticated ? 'signed in' : 'not signed in'}</h3></div>
+        <div className={'mb-4'}><h3>status: {auth.isAuthenticated ? 'signed in' : 'not signed in'}</h3></div>
 
         <Button onClick={signOut} variant={'outlined'} disabled={auth.isLoading}>
           Sign out


### PR DESCRIPTION
# 概要
- Next.jsのSSRでCognitoからサインイン済ユーザの情報を取得するよう対応

# メモ

- ALBのプロトコルがhttpの状態で、 `Auth.currentAuthenticatedUser` を取得しようとするとエラーとなる
- プロトコルが `https` ならば問題なく動作した

```bash
> aws-cognito-auth-trial@0.1.0 start
--
> next start
ready - started server on 0.0.0.0:3000, url: http://localhost:3000
info  - Loaded env from /aws-cognito-auth-trial/.env.production.local
info  - Loaded env from /aws-cognito-auth-trial/.env.production
warn  - SWC minify release candidate enabled. https://nextjs.org/docs/messages/swc-minify-enabled
Warning: For production Image Optimization with Next.js, the optional 'sharp' package is strongly recommended. Run 'yarn add sharp', and Next.js will use it automatically for Image Optimization.
Read more: https://nextjs.org/docs/messages/sharp-missing-in-production
not signed in.
401 - Unauthorized
The user is not authenticated
Error: 401 - Unauthorized
at /aws-cognito-auth-trial/.next/server/pages/api/greeting/[message].js:37:15
at processTicksAndRejections (node:internal/process/task_queues:96:5)
at async SsrAuthorizer (/aws-cognito-auth-trial/.next/server/pages/api/greeting/[message].js:27:12)
at async GreetingMessageHandler (/aws-cognito-auth-trial/.next/server/pages/api/greeting/[message].js:44:18)
at async Object.apiResolver (/aws-cognito-auth-trial/node_modules/next/dist/server/api-utils/node.js:185:9)
at async NextNodeServer.runApi (/aws-cognito-auth-trial/node_modules/next/dist/server/next-server.js:395:9)
at async Object.fn (/aws-cognito-auth-trial/node_modules/next/dist/server/base-server.js:496:37)
at async Router.execute (/aws-cognito-auth-trial/node_modules/next/dist/server/router.js:226:36)
at async NextNodeServer.run (/aws-cognito-auth-trial/node_modules/next/dist/server/base-server.js:606:29)
at async NextNodeServer.handleRequest (/aws-cognito-auth-trial/node_modules/next/dist/server/base-server.js:321:20)
node:events:505
throw er; // Unhandled 'error' event
^
Error [ERR_STREAM_WRITE_AFTER_END]: write after end
at new NodeError (node:internal/errors:372:5)
at ServerResponse.end (node:_http_outgoing:846:15)
at ServerResponse.end (/aws-cognito-auth-trial/node_modules/next/dist/compiled/compression/index.js:22:783)
at ServerResponse.apiRes.end (/aws-cognito-auth-trial/node_modules/next/dist/server/api-utils/node.js:161:25)
at Object.sendError (/aws-cognito-auth-trial/node_modules/next/dist/server/api-utils/index.js:109:9)
at Object.apiResolver (/aws-cognito-auth-trial/node_modules/next/dist/server/api-utils/node.js:203:25)
at processTicksAndRejections (node:internal/process/task_queues:96:5)
at async NextNodeServer.runApi (/aws-cognito-auth-trial/node_modules/next/dist/server/next-server.js:395:9)
at async Object.fn (/aws-cognito-auth-trial/node_modules/next/dist/server/base-server.js:496:37)
at async Router.execute (/aws-cognito-auth-trial/node_modules/next/dist/server/router.js:226:36)
Emitted 'error' event on ServerResponse instance at:
at emitErrorNt (node:_http_outgoing:726:9)
at processTicksAndRejections (node:internal/process/task_queues:84:21) {
code: 'ERR_STREAM_WRITE_AFTER_END'
}
```

- 以下を見ていて
   - https://github.com/aws-amplify/amplify-js/issues/8011
- cookie保存の場合、 `secure: true/false` でhttpを許容するかどうかを制御できる
- 今の実装はlocalStorage保存としている(が、それだけ)
- なので、httpが弾かれる設定になっているのやも